### PR TITLE
makefile: Allow CFLAGS/LDFLAGS from environment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OUT := mybw
 
-CFLAGS := -O2 -Wall -fno-builtin
-LDFLAGS := -static -static-libgcc
+CFLAGS += -O2 -Wall -fno-builtin
+LDFLAGS += -static -static-libgcc
 
 SRCS := mybw.c
 OBJS := $(SRCS:.c=.o)


### PR DESCRIPTION
This helps in cross-compilation where the flags passed from environment will matter much e.g. ABI, architecture etc.

Signed-off-by: Khem Raj <raj.khem@gmail.com>